### PR TITLE
Update gemspec and fix service model

### DIFF
--- a/lib/utilityapi/model/service.rb
+++ b/lib/utilityapi/model/service.rb
@@ -120,7 +120,7 @@ module UtilityApi
       :utility_tariff_name, :utility_service_address, :utility_billing_account,
       :utility_billing_contact, :utility_billing_address, :utility_meter_number,
       :bill_count, :interval_count, :created, :active_until, :latest,
-      :bill_coverage, :interval_coverage,
+      :bill_coverage, :interval_coverage, :service_class,
       :bill_sources, # XXX: this is not documented in the API
       #:modified # XXX: this is listed in docs, but not returned
       )

--- a/utilityapi.gemspec
+++ b/utilityapi.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.version       = UtilityApi::VERSION
   spec.author        = 'AUTHOR'
   spec.email         = 'EMAIL'
-  spec.homepage      = 'HOMEPAGE'
+  spec.homepage      = 'https://github.com/utilityapi/ruby-sdk'
 
   spec.summary       = 'Ruby SDK for the Utility API websity API: http://utilityapi.com/api.'
   spec.description   = <<-DESCRIPTION


### PR DESCRIPTION
Setting the homepage in the gemspec fixes a bundle failure.

At some point UtilityAPI added `service_class` to the response for `list_for_account`. Since this key was not present in the struct definition for the service model, it was throwing an exception. Adding `service_class` to the struct definition fixed this.